### PR TITLE
deleting blobs directory

### DIFF
--- a/blobs/ruby/bundler-1.6.3.gem
+++ b/blobs/ruby/bundler-1.6.3.gem
@@ -1,1 +1,0 @@
-/home/lynn/peter/mongodb3-bosh-release/.blobs/c8a000f75b6a6f60d9fb727f8076ec9171e14c20

--- a/blobs/ruby/ruby-2.1.4.tar.gz
+++ b/blobs/ruby/ruby-2.1.4.tar.gz
@@ -1,1 +1,0 @@
-/home/lynn/peter/mongodb3-bosh-release/.blobs/29e9cfdd9e989b7621d7696ef3f970262a08dbc3


### PR DESCRIPTION
Since you've added blobs in S3, blob dir is no longer required :)

best